### PR TITLE
make adapter more stable

### DIFF
--- a/src/adapter/base.js
+++ b/src/adapter/base.js
@@ -1,25 +1,27 @@
 const log4js = require('log4js');
 const cluster = require('cluster');
 
+const _logger = Symbol('_logger');
+
 module.exports = class {
   constructor() {
-    this._logger = {};
+    this[_logger] = {};
   }
   
   debug(...args) {
-    return this._logger.debug(...args);
+    return this[_logger].debug(...args);
   }
 
   info(...args) {
-    return this._logger.info(...args);
+    return this[_logger].info(...args);
   }
 
   warn(...args) {
-    return this._logger.warn(...args);
+    return this[_logger].warn(...args);
   }
 
   error(...args) {
-    return this._logger.error(...args);
+    return this[_logger].error(...args);
   }
   
   /**
@@ -30,11 +32,11 @@ module.exports = class {
   }
 
   /**
-   * log4js getLogger
+   * log4js setLogger
    */
-  getLogger(config, category) {
+  setLogger(config, category) {
     this.configure(config);
-    return log4js.getLogger(category);
+    this[_logger] = log4js.getLogger(category);
   }
 
   /**

--- a/src/adapter/console.js
+++ b/src/adapter/console.js
@@ -15,6 +15,6 @@ module.exports = class ConsoleLogger extends Base {
       ]
     }, lConfig);
 
-    this._logger = this.getLogger(config);
+    this.setLogger(config);
   }
 };

--- a/src/adapter/datefile.js
+++ b/src/adapter/datefile.js
@@ -18,6 +18,6 @@ module.exports = class DateFileLogger extends Base {
     //check cluster mode
     config = this.isCluster(config, clusterMode);
 
-    this._logger = this.getLogger(config);
+    this.setLogger(config);
   }
 };

--- a/src/adapter/file.js
+++ b/src/adapter/file.js
@@ -17,6 +17,6 @@ module.exports = class FileLogger extends Base {
     //check cluster mode
     config = this.isCluster(config, clusterMode);
 
-    this._logger = this.getLogger(config);
+    this.setLogger(config);
   }
 };

--- a/src/adapter/gelf.js
+++ b/src/adapter/gelf.js
@@ -10,6 +10,6 @@ module.exports = class GelfLogger extends Base {
       appenders: [{type: 'gelf', host, hostname, port, facility}]
     }, lConfig);
 
-    this._logger = this.getLogger(config);
+    this.setLogger(config);
   }
 };


### PR DESCRIPTION
```js
const Logger = require('./src/index.js');

class MyHandle extends Logger.Console{
  info(...args){
    this._logger = null;  //prevent this mistake
    super.info(...args, 1);
  }
}

let logger = new Logger({
  handle: MyHandle
});

logger.info('test');
```