### PR TITLE
Set mode and numBackups by config.

### DIFF
--- a/src/adapter/datefile.js
+++ b/src/adapter/datefile.js
@@ -3,12 +3,12 @@ const Base = require('./base');
 module.exports = class DateFileLogger extends Base {
   formatConfig(config) {
     // eslint-disable-next-line prefer-const
-    let {level, filename, pattern, alwaysIncludePattern, absolute, layout} = config;
+    let {level, filename, pattern, alwaysIncludePattern, absolute, layout, mode, numBackups} = config;
     level = level ? level.toUpperCase() : 'ALL';
 
     return Object.assign({
       appenders: {
-        dateFile: {type: 'dateFile', filename, pattern, alwaysIncludePattern, absolute, layout}
+        dateFile: {type: 'dateFile', filename, pattern, alwaysIncludePattern, absolute, layout, mode, numBackups}
       },
       categories: {
         default: {appenders: ['dateFile'], level}

--- a/src/adapter/file.js
+++ b/src/adapter/file.js
@@ -3,13 +3,13 @@ const Base = require('./base');
 module.exports = class FileLogger extends Base {
   formatConfig(config) {
     // eslint-disable-next-line prefer-const
-    let {level, filename, maxLogSize, backups, absolute, layout} = config;
+    let {level, filename, maxLogSize, backups, absolute, layout, mode} = config;
     level = level ? level.toUpperCase() : 'ALL';
 
     // combine config for file appender, common config for log4js
     return Object.assign({
       appenders: {
-        file: {type: 'file', filename, maxLogSize, backups, absolute, layout}
+        file: {type: 'file', filename, maxLogSize, backups, absolute, layout, mode}
       },
       categories: {
         default: {appenders: ['file'], level}


### PR DESCRIPTION
Hi,

log4js在新版本中更改了部分默认值，例如datefile appender设置的保持文件数量默认值修改为了1，这些修改会导致在更新1.3.0后旧的日志文件被删除等情况。

由于think-logger3没有读取numBackups等参数，应用程序没法直接更改相关设置。所以，在adapter内增加了读取config的mode及numBackups参数并传递至log4js。
